### PR TITLE
Search default python include folder for Eigen

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -175,9 +175,9 @@ list_packages = [
 ## Infos from release ##
 ########################
 
-here = os.path.abspath(os.path.dirname(__file__)
+here = os.path.abspath( os.path.dirname(__file__) )
 
-with open( os.path.join(here, "SBCK/__release.py") , "r" ) as f:
+with open( os.path.join(here, "SBCK/__release.py"), "r" ) as f:
 	lines = f.readlines()
 
 version_major = None
@@ -224,7 +224,7 @@ setup(
 	cmdclass         = {'build_ext': BuildExt},
 	zip_safe         = False,
 	packages         = list_packages,
-	package_dir      = { "SBCK" : os.path.join( here, "SBCK" ) }
+	package_dir      = { "SBCK" : os.path.join(here, "SBCK") }
 )
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,6 +23,7 @@
 ###############
 
 import sys,os
+import sysconfig
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 import setuptools
@@ -63,8 +64,7 @@ class get_pybind_include(object):##{{{
 ##}}}
 
 def get_eigen_include( propose_path = "" ):##{{{
-	
-	possible_path = [ propose_path , "/usr/include/" , "/usr/local/include/" ]
+	possible_path = [ propose_path , os.path.dirname(sysconfig.get_paths()['include']), "/usr/include/" , "/usr/local/include/" ]
 	if os.environ.get("HOME") is not None:
 		possible_path.append( os.path.join( os.environ["HOME"] , ".local/include" ) )
 	

--- a/python/setup.py
+++ b/python/setup.py
@@ -44,7 +44,12 @@ for i,arg in enumerate(sys.argv):
 
 if i_eigen > -1:
 	del sys.argv[i_eigen]
+	
+############################
+## Python path resolution ##
+############################
 
+here = os.path.abspath( os.path.dirname(__file__) )
 
 ################################################################
 ## Some class and function to compile with Eigen and pybind11 ##
@@ -142,8 +147,8 @@ class BuildExt(build_ext):##{{{
 
 ext_modules = [
 	Extension(
-		'SBCK.tools.__tools_cpp',
-		['SBCK/tools/src/tools.cpp'],
+		os.path.join(here, 'SBCK.tools.__tools_cpp'),
+		[ os.path.join(here, 'SBCK/tools/src/tools.cpp') ],
 		include_dirs=[
 			# Path to pybind11 headers
 			get_eigen_include(eigen_usr_include),
@@ -152,9 +157,9 @@ ext_modules = [
 		],
 		language='c++',
 		depends = [
-			"SBCK/tools/src/SparseHist.hpp"
-			"SBCK/tools/src/NetworkSimplex.hpp"
-			"SBCK/tools/src/NetworkSimplexLemon.hpp"
+			os.path.join(here, "SBCK/tools/src/SparseHist.hpp")
+			os.path.join(here, "SBCK/tools/src/NetworkSimplex.hpp")
+			os.path.join(here, "SBCK/tools/src/NetworkSimplexLemon.hpp")
 			]
 	),
 ]
@@ -174,8 +179,6 @@ list_packages = [
 ########################
 ## Infos from release ##
 ########################
-
-here = os.path.abspath( os.path.dirname(__file__) )
 
 with open( os.path.join(here, "SBCK/__release.py"), "r" ) as f:
 	lines = f.readlines()

--- a/python/setup.py
+++ b/python/setup.py
@@ -157,9 +157,9 @@ ext_modules = [
 		],
 		language='c++',
 		depends = [
-			os.path.join(here, "SBCK/tools/src/SparseHist.hpp")
-			os.path.join(here, "SBCK/tools/src/NetworkSimplex.hpp")
-			os.path.join(here, "SBCK/tools/src/NetworkSimplexLemon.hpp")
+			"SBCK/tools/src/SparseHist.hpp"
+			"SBCK/tools/src/NetworkSimplex.hpp"
+			"SBCK/tools/src/NetworkSimplexLemon.hpp"
 			]
 	),
 ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -147,7 +147,7 @@ class BuildExt(build_ext):##{{{
 
 ext_modules = [
 	Extension(
-		os.path.join(here, 'SBCK.tools.__tools_cpp'),
+		"SBCK.tools.__tools_cpp",
 		[ os.path.join(here, 'SBCK/tools/src/tools.cpp') ],
 		include_dirs=[
 			# Path to pybind11 headers

--- a/python/setup.py
+++ b/python/setup.py
@@ -22,7 +22,8 @@
 ## Libraries ##
 ###############
 
-import sys,os
+import os
+import sys
 import sysconfig
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
@@ -174,7 +175,9 @@ list_packages = [
 ## Infos from release ##
 ########################
 
-with open( "SBCK/__release.py" , "r" ) as f:
+here = os.path.abspath(os.path.dirname(__file__)
+
+with open( os.path.join(here, "SBCK/__release.py") , "r" ) as f:
 	lines = f.readlines()
 
 version_major = None
@@ -221,7 +224,7 @@ setup(
 	cmdclass         = {'build_ext': BuildExt},
 	zip_safe         = False,
 	packages         = list_packages,
-	package_dir      = { "SBCK" : "SBCK" }
+	package_dir      = { "SBCK" : os.path.join( here, "SBCK" ) }
 )
 
 


### PR DESCRIPTION
Fixes #2.
This uses `sysconfig` (builtin) to guess where python's own include files are installed and uses that folder a supplementary candidate to find Eigen's headers. This is useful for virtual environments.

This allows the installation of dependencies with `conda` and then of this package through pip (without having to pass the include folder of Eigen).