### PR TITLE
Add conda installation doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ If using conda to manage environments and packages, the module can be installed 
 ```
 conda create -n sbck eigen numpy scipy pybind11 cxx-compiler
 conda activate sbck
-python3 setup.py install --user
+python setup.py install
 ```
+
+Make sure that you never try to import the package in an interpreter who's current working directory is the source folder. This would fail with `ModuleNotFoundError: No module named 'SBCK.tools.__tools_cpp'` since the compiled version of the module is not present in the source folder, but rather in the conda environment itself.
 
 ## R instruction
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Requires:
 - numpy
 - scipy
 - pybind11
+- a C++ compiler
 
 For python, just use the command:
 ```
@@ -62,6 +63,15 @@ python3 setup.py install --user
 If the Eigen library is not found, use:
 ```
 python3 setup.py install --user eigen="path-to-eigen"
+```
+
+### Conda
+
+If using conda to manage environments and packages, the module can be installed with:
+```
+conda create -n sbck eigen numpy scipy pybind11 cxx-compiler
+conda activate sbck
+python3 setup.py install --user
 ```
 
 ## R instruction


### PR DESCRIPTION
Hi!

This PR adds a bit of documentation on how to install SBCK in a conda environment. It also adds a mention of the needed C++ compiler for installing the python version.